### PR TITLE
chore(desktop): change dev port from 1420 to 8317

### DIFF
--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.hezhangjian.chuqin",
   "build": {
     "beforeDevCommand": "pnpm dev",
-    "devUrl": "http://localhost:1420",
+    "devUrl": "http://localhost:8317",
     "beforeBuildCommand": "pnpm build",
     "frontendDist": "../dist"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,14 +14,14 @@ export default defineConfig(async () => ({
   clearScreen: false,
   // 2. tauri expects a fixed port, fail if that port is not available
   server: {
-    port: 1420,
+    port: 8317,
     strictPort: true,
     host: host || false,
     hmr: host
       ? {
           protocol: "ws",
           host,
-          port: 1421,
+          port: 8318,
         }
       : undefined,
     watch: {


### PR DESCRIPTION
## Summary

- Change Vite dev server port from `1420` to `8317`
- Update Tauri `devUrl` to match the new port
- Update HMR WebSocket port from `1421` to `8318`