### PR TITLE
feat(desktop): add Windows transparent titlebar

### DIFF
--- a/desktop/capabilities/default.json
+++ b/desktop/capabilities/default.json
@@ -5,6 +5,10 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
+    "core:window:allow-close",
+    "core:window:allow-is-maximized",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
     "opener:default",
     {
       "identifier": "opener:allow-open-path",

--- a/desktop/src/lib.rs
+++ b/desktop/src/lib.rs
@@ -7,7 +7,6 @@ mod commands;
 use chuqin_core::AppContext;
 use std::sync::Mutex;
 use tauri::Emitter;
-use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 
 const CLOSE_ACTIVE_TAB_EVENT: &str = "chuqin://close-active-tab";
 const CLOSE_TAB_MENU_ID: &str = "close_active_tab";
@@ -27,46 +26,63 @@ pub fn run() {
             context: Mutex::new(context),
         })
         .setup(|app| {
-            let handle = app.handle();
-            let close_tab = MenuItemBuilder::with_id(CLOSE_TAB_MENU_ID, "Close Tab")
-                .accelerator("CmdOrCtrl+W")
-                .build(handle)?;
-            let app_menu = SubmenuBuilder::new(handle, "chuqin")
-                .about(None)
-                .separator()
-                .services()
-                .separator()
-                .hide()
-                .hide_others()
-                .show_all()
-                .separator()
-                .quit()
-                .build()?;
-            let file_menu = SubmenuBuilder::new(handle, "File").item(&close_tab).build()?;
-            let edit_menu = SubmenuBuilder::new(handle, "Edit")
-                .undo()
-                .redo()
-                .separator()
-                .cut()
-                .copy()
-                .paste()
-                .select_all()
-                .build()?;
-            let window_menu = SubmenuBuilder::new(handle, "Window")
-                .minimize()
-                .maximize()
-                .fullscreen()
-                .separator()
-                .bring_all_to_front()
-                .build()?;
-            let menu = MenuBuilder::new(handle)
-                .item(&app_menu)
-                .item(&file_menu)
-                .item(&edit_menu)
-                .item(&window_menu)
-                .build()?;
+            #[cfg(not(target_os = "windows"))]
+            {
+                use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 
-            app.set_menu(menu)?;
+                let handle = app.handle();
+                let close_tab = MenuItemBuilder::with_id(CLOSE_TAB_MENU_ID, "Close Tab")
+                    .accelerator("CmdOrCtrl+W")
+                    .build(handle)?;
+                let app_menu = SubmenuBuilder::new(handle, "chuqin")
+                    .about(None)
+                    .separator()
+                    .services()
+                    .separator()
+                    .hide()
+                    .hide_others()
+                    .show_all()
+                    .separator()
+                    .quit()
+                    .build()?;
+                let file_menu = SubmenuBuilder::new(handle, "File").item(&close_tab).build()?;
+                let edit_menu = SubmenuBuilder::new(handle, "Edit")
+                    .undo()
+                    .redo()
+                    .separator()
+                    .cut()
+                    .copy()
+                    .paste()
+                    .select_all()
+                    .build()?;
+                let window_menu = SubmenuBuilder::new(handle, "Window")
+                    .minimize()
+                    .maximize()
+                    .fullscreen()
+                    .separator()
+                    .bring_all_to_front()
+                    .build()?;
+                let menu = MenuBuilder::new(handle)
+                    .item(&app_menu)
+                    .item(&file_menu)
+                    .item(&edit_menu)
+                    .item(&window_menu)
+                    .build()?;
+
+                app.set_menu(menu)?;
+            }
+
+            #[cfg(target_os = "windows")]
+            {
+                use tauri::Manager;
+                use tauri::window::{Effect, EffectsBuilder};
+
+                if let Some(window) = app.get_webview_window("main") {
+                    window.set_decorations(false)?;
+                    window.set_shadow(true)?;
+                    window.set_effects(EffectsBuilder::new().effect(Effect::MicaLight).build())?;
+                }
+            }
 
             Ok(())
         })

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -15,6 +15,8 @@
         "title": "chuqin",
         "width": 1440,
         "height": 960,
+        "transparent": true,
+        "backgroundColor": "#00000000",
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
         "trafficLightPosition": {

--- a/ui/App.css
+++ b/ui/App.css
@@ -3,7 +3,7 @@
   --main-area-background: #ffffff;
   --panel-border: #dedee1;
   color: #242629;
-  background: var(--main-area-background);
+  background: transparent;
   font-family:
     Inter,
     ui-sans-serif,
@@ -28,6 +28,7 @@ body {
   min-width: 320px;
   min-height: 100vh;
   overflow: hidden;
+  background: transparent;
 }
 
 button {
@@ -43,6 +44,13 @@ button {
   overflow: hidden;
   background: var(--main-area-background);
   transition: grid-template-columns 180ms ease;
+}
+
+.app-layout.is-windows {
+  --panel-background: rgb(246 246 246 / 78%);
+  --main-area-background: rgb(255 255 255 / 86%);
+  --panel-border: rgb(175 178 184 / 42%);
+  background: rgb(255 255 255 / 70%);
 }
 
 .app-layout.resizing-panel {
@@ -69,6 +77,7 @@ button {
 .titlebar-actions {
   display: flex;
   align-items: center;
+  gap: 8px;
   min-width: 0;
   padding: 0 10px;
 }
@@ -78,8 +87,13 @@ button {
   padding-left: 78px;
 }
 
+.app-layout.is-windows .titlebar-actions.left {
+  padding-left: 10px;
+}
+
 .titlebar-actions.right {
   justify-content: flex-end;
+  padding-right: 0;
 }
 
 .titlebar-toggle {

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -4,6 +4,7 @@ import {useEffect} from 'react';
 import {MainArea} from './components/main-area/MainArea';
 import {Sidebar} from './components/sidebar/Sidebar';
 import {ToolPanel} from './components/tools/ToolPanel';
+import {WindowControls} from './components/window-controls/WindowControls';
 import {useAppLayout} from './hooks/useAppLayout';
 import {useFileExplorer} from './hooks/useFileExplorer';
 import {useMainAreaTabs} from './hooks/useMainAreaTabs';
@@ -12,10 +13,15 @@ import './App.css';
 
 const closeActiveTabEvent = 'chuqin://close-active-tab';
 
+function isWindowsPlatform() {
+  return navigator.userAgent.includes('Windows');
+}
+
 function App() {
   const appLayout = useAppLayout();
   const fileExplorer = useFileExplorer();
   const mainAreaTabs = useMainAreaTabs();
+  const isWindows = isWindowsPlatform();
 
   function closeActiveTab() {
     if (mainAreaTabs.activeTab) {
@@ -78,7 +84,10 @@ function App() {
   }
 
   return (
-    <main className={`app-layout${appLayout.isResizingPanel ? ' resizing-panel' : ''}`} style={appLayout.rootStyle}>
+    <main
+      className={`app-layout${isWindows ? ' is-windows' : ''}${appLayout.isResizingPanel ? ' resizing-panel' : ''}`}
+      style={appLayout.rootStyle}
+    >
       <header className="app-titlebar" data-tauri-drag-region>
         <div className="titlebar-actions left" data-tauri-drag-region>
           <button
@@ -100,6 +109,7 @@ function App() {
           >
             <span className="sidebar-toggle-icon right" aria-hidden="true" />
           </button>
+          {isWindows ? <WindowControls /> : null}
         </div>
       </header>
 

--- a/ui/components/window-controls/WindowControls.css
+++ b/ui/components/window-controls/WindowControls.css
@@ -1,0 +1,118 @@
+.window-controls {
+  display: flex;
+  align-self: stretch;
+  height: 44px;
+  margin-left: 4px;
+  -webkit-app-region: no-drag;
+}
+
+.window-control {
+  position: relative;
+  display: grid;
+  width: 46px;
+  height: 44px;
+  place-items: center;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: #1f2328;
+  -webkit-app-region: no-drag;
+}
+
+.window-control:hover {
+  background: rgb(0 0 0 / 8%);
+}
+
+.window-control:active {
+  background: rgb(0 0 0 / 12%);
+}
+
+.window-control:focus-visible {
+  outline: 2px solid #2f6fed;
+  outline-offset: -3px;
+}
+
+.window-control.close:hover {
+  background: #c42b1c;
+  color: #ffffff;
+}
+
+.window-control.close:active {
+  background: #a62015;
+  color: #ffffff;
+}
+
+.window-control-icon {
+  position: relative;
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+
+.window-control-icon.minimize::before {
+  position: absolute;
+  top: 8px;
+  left: 3px;
+  width: 10px;
+  height: 1px;
+  background: currentColor;
+  content: '';
+}
+
+.window-control-icon.maximize::before {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  width: 8px;
+  height: 8px;
+  border: 1px solid currentColor;
+  content: '';
+}
+
+.window-control-icon.restore::before,
+.window-control-icon.restore::after {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border: 1px solid currentColor;
+  content: '';
+}
+
+.window-control-icon.restore::before {
+  top: 3px;
+  left: 5px;
+}
+
+.window-control-icon.restore::after {
+  top: 6px;
+  left: 2px;
+  background: rgb(246 246 246 / 88%);
+}
+
+.window-control:hover .window-control-icon.restore::after {
+  background: rgb(232 232 232 / 92%);
+}
+
+.window-control.close:hover .window-control-icon.restore::after {
+  background: #c42b1c;
+}
+
+.window-control-icon.close::before,
+.window-control-icon.close::after {
+  position: absolute;
+  top: 7px;
+  left: 3px;
+  width: 10px;
+  height: 1px;
+  background: currentColor;
+  content: '';
+  transform-origin: center;
+}
+
+.window-control-icon.close::before {
+  transform: rotate(45deg);
+}
+
+.window-control-icon.close::after {
+  transform: rotate(-45deg);
+}

--- a/ui/components/window-controls/WindowControls.tsx
+++ b/ui/components/window-controls/WindowControls.tsx
@@ -1,0 +1,82 @@
+import {getCurrentWindow} from '@tauri-apps/api/window';
+import {useCallback, useEffect, useState} from 'react';
+import './WindowControls.css';
+
+const appWindow = getCurrentWindow();
+
+export function WindowControls() {
+  const [isMaximized, setIsMaximized] = useState(false);
+
+  const syncMaximizedState = useCallback(async () => {
+    try {
+      setIsMaximized(await appWindow.isMaximized());
+    } catch (error) {
+      console.error(error);
+    }
+  }, []);
+
+  useEffect(() => {
+    void syncMaximizedState();
+
+    let isDisposed = false;
+    let unlistenResize: (() => void) | undefined;
+
+    appWindow.onResized(syncMaximizedState).then((dispose) => {
+      if (isDisposed) {
+        dispose();
+        return;
+      }
+
+      unlistenResize = dispose;
+    });
+
+    return () => {
+      isDisposed = true;
+      unlistenResize?.();
+    };
+  }, [syncMaximizedState]);
+
+  async function minimizeWindow() {
+    try {
+      await appWindow.minimize();
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async function toggleMaximizeWindow() {
+    try {
+      await appWindow.toggleMaximize();
+      await syncMaximizedState();
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async function closeWindow() {
+    try {
+      await appWindow.close();
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  return (
+    <div className="window-controls" role="group" aria-label="Window controls">
+      <button aria-label="Minimize window" className="window-control" onClick={minimizeWindow} type="button">
+        <span className="window-control-icon minimize" aria-hidden="true" />
+      </button>
+      <button
+        aria-label={isMaximized ? 'Restore window' : 'Maximize window'}
+        className="window-control"
+        onClick={toggleMaximizeWindow}
+        type="button"
+      >
+        <span className={`window-control-icon ${isMaximized ? 'restore' : 'maximize'}`} aria-hidden="true" />
+      </button>
+      <button aria-label="Close window" className="window-control close" onClick={closeWindow} type="button">
+        <span className="window-control-icon close" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a transparent Windows window surface with MicaLight and custom titlebar controls
- render Windows-only minimize, maximize/restore, and close controls in the React titlebar
- hide the native menu bar on Windows so it does not overlap the transparent custom titlebar

## Verification
- cargo check
- pnpm build