### PR TITLE
feat(cli): add excel create command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -597,6 +597,7 @@ dependencies = [
  "dirs",
  "docx-rs",
  "ppt-rs",
+ "rust_xlsxwriter",
  "serde",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
@@ -3193,6 +3194,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust_xlsxwriter"
+version = "0.95.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f281b687352597d29efaad39701d1167d5c48aa76fb973e392bc13e9d44e7f36"
+dependencies = [
+ "zip 7.2.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5588,6 +5598,20 @@ dependencies = [
  "sha1",
  "time",
  "zstd",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
 ]
 
 [[package]]

--- a/cli/src/commands/excel.rs
+++ b/cli/src/commands/excel.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use chuqin_core::{AppContext, Error, excel::CreateOptions};
+use clap::{Args, Subcommand};
+
+#[derive(Args, Debug)]
+pub struct ExcelCommand {
+    #[command(subcommand)]
+    pub command: ExcelSubcommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ExcelSubcommand {
+    Create(CreateWorkbookArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct CreateWorkbookArgs {
+    pub title: String,
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+    #[arg(long)]
+    pub overwrite: bool,
+    #[arg(long)]
+    pub template: Option<String>,
+}
+
+pub fn run(ctx: &AppContext, command: ExcelCommand) -> Result<(), Error> {
+    match command.command {
+        ExcelSubcommand::Create(args) => {
+            let output_path = chuqin_core::excel::create_excel(
+                ctx,
+                &args.title,
+                &CreateOptions {
+                    output: args.output,
+                    overwrite: args.overwrite,
+                    template: args.template,
+                },
+            )?;
+            println!("Created Excel: {}", output_path.display());
+        }
+    }
+
+    Ok(())
+}

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod excel;
 pub mod outlook;
 pub mod pdf;
 pub mod ppt;
@@ -13,6 +14,7 @@ pub fn run(command: Command) -> Result<(), Error> {
         Command::Version => {
             println!("{}", env!("CARGO_PKG_VERSION"));
         }
+        Command::Excel(command) => excel::run(&ctx, command)?,
         Command::Outlook(command) => outlook::run(&ctx, command)?,
         Command::Pdf(command) => pdf::run(&ctx, command)?,
         Command::Ppt(command) => ppt::run(&ctx, command)?,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -2,7 +2,7 @@ mod commands;
 
 use clap::{Parser, Subcommand};
 
-use commands::{outlook, pdf, ppt, word};
+use commands::{excel, outlook, pdf, ppt, word};
 
 #[derive(Parser, Debug)]
 #[command(
@@ -18,7 +18,9 @@ struct Cli {
 
 #[derive(Subcommand, Debug)]
 enum Command {
+    // Keep `version` first as the universal metadata command; sort feature commands alphabetically.
     Version,
+    Excel(excel::ExcelCommand),
     Outlook(outlook::OutlookCommand),
     Pdf(pdf::PdfCommand),
     Ppt(ppt::PptCommand),

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dirs = "6"
 docx-rs = "0.4"
 ppt-rs = "0.2"
+rust_xlsxwriter = "0.95"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
 toml = "1"

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -20,6 +20,8 @@ pub enum Error {
     PathNotFound(String),
     #[error("PPTX generation error: {0}")]
     Pptx(#[from] ppt_rs::PptxError),
+    #[error("XLSX generation error: {0}")]
+    Xlsx(#[from] rust_xlsxwriter::XlsxError),
     #[error("Zip error: {0}")]
     Zip(#[from] zip::result::ZipError),
 }

--- a/core/src/excel/create.rs
+++ b/core/src/excel/create.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::path::PathBuf;
+
+use super::generator::write_default_xlsx;
+use crate::Result;
+use crate::context::AppContext;
+use crate::util::paths::{ensure_writable_output, resolve_output_path};
+
+#[derive(Debug, Clone)]
+pub struct CreateOptions {
+    pub output: Option<PathBuf>,
+    pub overwrite: bool,
+    pub template: Option<String>,
+}
+
+pub fn create_excel(ctx: &AppContext, title: &str, options: &CreateOptions) -> Result<PathBuf> {
+    let output_path = resolve_output_path(options.output.as_ref(), title, "xlsx");
+    ensure_writable_output(&output_path, options.overwrite)?;
+
+    let template_dir = ctx.templates_dir.join("EXCEL");
+
+    if let Some(ref template_name) = options.template {
+        let template_path = template_dir.join(format!("{template_name}.xlsx"));
+        if template_path.is_file() {
+            fs::copy(&template_path, &output_path)?;
+            return Ok(output_path);
+        }
+    }
+
+    let default_template = template_dir.join("default.xlsx");
+    if default_template.is_file() {
+        fs::copy(&default_template, &output_path)?;
+        return Ok(output_path);
+    }
+
+    write_default_xlsx(&output_path, title)?;
+    Ok(output_path)
+}

--- a/core/src/excel/generator.rs
+++ b/core/src/excel/generator.rs
@@ -1,0 +1,12 @@
+use std::path::Path;
+
+use crate::Result;
+use rust_xlsxwriter::Workbook;
+
+pub fn write_default_xlsx(output_path: &Path, title: &str) -> Result<()> {
+    let mut workbook = Workbook::new();
+    let worksheet = workbook.add_worksheet();
+    worksheet.write(0, 0, title)?;
+    workbook.save(output_path)?;
+    Ok(())
+}

--- a/core/src/excel/mod.rs
+++ b/core/src/excel/mod.rs
@@ -1,0 +1,4 @@
+mod create;
+mod generator;
+
+pub use create::{CreateOptions, create_excel};

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 mod config;
 mod context;
 mod error;
+pub mod excel;
 mod fs;
 mod outlook;
 pub mod ppt;

--- a/core/src/util/zip_utils.rs
+++ b/core/src/util/zip_utils.rs
@@ -1,5 +1,4 @@
 use std::fs::File;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use zip::CompressionMethod;
@@ -25,25 +24,6 @@ pub fn write_zip_archive(archive_path: &Path, base_dir: &Path, files: &[PathBuf]
 
         let mut input = File::open(path)?;
         std::io::copy(&mut input, &mut zip)?;
-    }
-
-    zip.finish()?;
-    Ok(())
-}
-
-/// Writes in-memory string content directly to a zip archive.
-///
-/// # Arguments
-/// - `output_path`: Output path for the zip file
-/// - `entries`: List of (filename, content) tuples representing zip entries
-pub fn write_zip_entries(output_path: &Path, entries: Vec<(String, String)>) -> Result<()> {
-    let file = File::create(output_path)?;
-    let mut zip = ZipWriter::new(file);
-    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-
-    for (name, content) in entries {
-        zip.start_file(name, options)?;
-        zip.write_all(content.as_bytes())?;
     }
 
     zip.finish()?;

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -12,6 +12,7 @@ CLI is organized into command groups.
 
 ## Examples
 
+- `chuqin excel create "Project Tracker"`: Create `./Project Tracker.xlsx` in the current directory.
 - `chuqin version`: Show the installed ChuQin version.
 - `chuqin pdf to-ppt ./demo.pdf`: Convert a PDF into a 16:9 PowerPoint deck.
 - `chuqin ppt create "Engineering Planning"`: Create `./Engineering Planning.pptx` in the current directory.
@@ -20,6 +21,7 @@ CLI is organized into command groups.
 
 CLI currently includes the following modules:
 
+- **[excel](./excel.md)**: Commands for Excel integrations.
 - **[gitcode](./gitcode.md)**: Commands for GitCode integrations.
 - **[gitee](./gitee.md)**: Commands for Gitee integrations.
 - **[outlook](./outlook.md)**: Commands for Outlook integrations.

--- a/docs/cli/excel.md
+++ b/docs/cli/excel.md
@@ -1,0 +1,61 @@
+# Excel
+
+The `excel` module contains commands for Excel-related integrations in ChuQin.
+
+## `create` Command
+
+Pass the workbook title directly after `create`:
+
+```bash
+chuqin excel create "Project Tracker"
+```
+
+This creates `./Project Tracker.xlsx` in the current directory.
+
+The provided title is used as:
+
+- The default output filename stem
+- The initial value in cell `A1`
+
+### Options
+
+Choose an explicit output path:
+
+```bash
+chuqin excel create "Project Tracker" -o ./output/project-tracker.xlsx
+```
+
+Overwrite an existing file:
+
+```bash
+chuqin excel create "Project Tracker" --overwrite
+```
+
+Use a custom template name:
+
+```bash
+chuqin excel create "Project Tracker" --template tracker
+```
+
+## Templates
+
+### Template Lookup Order
+
+1. If `--template tracker` is provided, ChuQin looks for:
+   - `$CHUQIN_DIR/Resources/Templates/EXCEL/tracker.xlsx`
+2. If the specified template is not found (or no `--template` is given), ChuQin looks for:
+   - `$CHUQIN_DIR/Resources/Templates/EXCEL/default.xlsx`
+3. If neither exists, ChuQin generates a built-in default XLSX.
+
+If a `.xlsx` template file is found, it is copied directly to the output location.
+
+### Template Shape
+
+Templates are `.xlsx` files placed in `$CHUQIN_DIR/Resources/Templates/EXCEL/`:
+
+```text
+Resources/Templates/EXCEL/
+├── tracker.xlsx
+├── default.xlsx        # fallback template (used when --template is not specified or not found)
+└── budget.xlsx
+```


### PR DESCRIPTION
## Summary
- add `chuqin excel create` with output, overwrite, and template options
- create XLSX files through `rust_xlsxwriter` instead of hand-written OOXML zip entries
- document the new Excel CLI module and template lookup order

## Verification
- `cargo check -p chuqin-core -p chuqin-cli`
- `cargo test -p chuqin-core -p chuqin-cli`
- `CHUQIN_DIR=/private/tmp/chuqin-empty-root cargo run -p chuqin-cli -- excel create "Project Tracker" -o /private/tmp/chuqin-excel-rust-xlsxwriter-check.xlsx --overwrite`