### PR TITLE
feat(ui): show file extensions in sidebar

### DIFF
--- a/ui/App.css
+++ b/ui/App.css
@@ -221,6 +221,14 @@ button {
   visibility: hidden;
 }
 
+.file-tree-label {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
 .file-tree-name {
   min-width: 0;
   overflow: hidden;
@@ -231,6 +239,21 @@ button {
   line-height: 1.25;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.file-tree-extension {
+  min-width: 34px;
+  color: #a8a8a8;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.file-tree-row.selected .file-tree-extension {
+  color: #666;
 }
 
 .file-tree-message,

--- a/ui/components/sidebar/Sidebar.tsx
+++ b/ui/components/sidebar/Sidebar.tsx
@@ -2,6 +2,23 @@ import type {CSSProperties, KeyboardEvent, PointerEvent} from 'react';
 import {getDirectoryStateFromRecord} from '../../hooks/useFileExplorer';
 import type {DirectoryState, TreeNode} from '../../hooks/useFileExplorer';
 
+function getFileNameParts(node: TreeNode) {
+  if (node.is_dir) {
+    return {extension: '', name: node.name};
+  }
+
+  const extensionStart = node.name.lastIndexOf('.');
+
+  if (extensionStart <= 0 || extensionStart === node.name.length - 1) {
+    return {extension: '', name: node.name};
+  }
+
+  return {
+    extension: node.name.slice(extensionStart + 1).toUpperCase(),
+    name: node.name.slice(0, extensionStart),
+  };
+}
+
 function FileTreeRow({
   depth,
   node,
@@ -20,6 +37,7 @@ function FileTreeRow({
   selectedPath?: string;
 }) {
   const isOpen = node.is_dir && directoryState.expanded;
+  const nameParts = getFileNameParts(node);
 
   return (
     <li className="file-tree-item">
@@ -30,13 +48,21 @@ function FileTreeRow({
           onSelect(node);
         }}
         style={{'--tree-depth': depth} as CSSProperties}
+        title={node.name}
         type="button"
       >
         <span
           className={`file-tree-chevron${isOpen ? ' expanded' : ''}${node.is_dir ? '' : ' hidden'}`}
           aria-hidden="true"
         />
-        <span className="file-tree-name">{node.name}</span>
+        <span className="file-tree-label">
+          <span className="file-tree-name">{nameParts.name}</span>
+          {nameParts.extension ? (
+            <span className="file-tree-extension" aria-label={`File type ${nameParts.extension}`}>
+              {nameParts.extension}
+            </span>
+          ) : null}
+        </span>
       </button>
 
       {directoryState.error ? (


### PR DESCRIPTION
## Summary
- split sidebar file names into name and extension parts
- show file extensions as right-aligned labels while preserving the full filename in the row title
- add CSS for stable sidebar label layout and selected-row extension color

## Verification
- `pnpm exec prettier --check ui/App.css ui/components/sidebar/Sidebar.tsx`
- `pnpm exec tsc --noEmit`