### PR TITLE
feat(ui): add file context menu actions

### DIFF
--- a/ui/App.css
+++ b/ui/App.css
@@ -260,25 +260,30 @@ button {
   position: fixed;
   z-index: 20;
   display: grid;
-  min-width: 136px;
+  min-width: 168px;
   padding: 6px;
-  border: 1px solid #d7d9de;
-  border-radius: 8px;
-  background: #ffffff;
-  box-shadow: 0 10px 28px rgb(20 22 26 / 16%);
-  gap: 2px;
+  border: 1px solid rgb(0 0 0 / 12%);
+  border-radius: 12px;
+  background: rgb(248 248 248 / 82%);
+  box-shadow:
+    0 18px 44px rgb(0 0 0 / 20%),
+    0 2px 8px rgb(0 0 0 / 10%);
+  gap: 1px;
+  -webkit-backdrop-filter: blur(28px) saturate(1.35);
+  backdrop-filter: blur(28px) saturate(1.35);
 }
 
 .file-tree-context-menu button {
   display: flex;
   align-items: center;
-  min-height: 30px;
-  padding: 0 10px;
+  min-height: 32px;
+  padding: 0 22px;
   border: 0;
-  border-radius: 5px;
+  border-radius: 8px;
   background: transparent;
-  color: #242629;
-  font-size: 13px;
+  color: #202124;
+  font-size: 15px;
+  font-weight: 500;
   letter-spacing: 0;
   text-align: left;
 }
@@ -286,16 +291,15 @@ button {
 .file-tree-context-menu button:hover,
 .file-tree-context-menu button:focus-visible {
   outline: none;
-  background: #f1f3f5;
+  background: #4d9bff;
+  color: #ffffff;
 }
 
-.file-tree-context-menu button.danger {
-  color: #a13f3f;
-}
-
-.file-tree-context-menu button.danger:hover,
-.file-tree-context-menu button.danger:focus-visible {
-  background: #f8eeee;
+.app-layout.is-windows .file-tree-context-menu {
+  border-color: rgb(0 0 0 / 14%);
+  border-radius: 10px;
+  background: rgb(250 250 250 / 92%);
+  box-shadow: 0 14px 34px rgb(0 0 0 / 18%);
 }
 
 .file-action-backdrop {

--- a/ui/App.css
+++ b/ui/App.css
@@ -256,6 +256,169 @@ button {
   color: #666;
 }
 
+.file-tree-context-menu {
+  position: fixed;
+  z-index: 20;
+  display: grid;
+  min-width: 136px;
+  padding: 6px;
+  border: 1px solid #d7d9de;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 10px 28px rgb(20 22 26 / 16%);
+  gap: 2px;
+}
+
+.file-tree-context-menu button {
+  display: flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: #242629;
+  font-size: 13px;
+  letter-spacing: 0;
+  text-align: left;
+}
+
+.file-tree-context-menu button:hover,
+.file-tree-context-menu button:focus-visible {
+  outline: none;
+  background: #f1f3f5;
+}
+
+.file-tree-context-menu button.danger {
+  color: #a13f3f;
+}
+
+.file-tree-context-menu button.danger:hover,
+.file-tree-context-menu button.danger:focus-visible {
+  background: #f8eeee;
+}
+
+.file-action-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: rgb(18 20 24 / 26%);
+}
+
+.file-action-dialog {
+  display: grid;
+  width: min(360px, 100%);
+  padding: 18px;
+  border: 1px solid #d7d9de;
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: 0 18px 44px rgb(20 22 26 / 22%);
+  gap: 14px;
+}
+
+.file-action-dialog h2,
+.file-action-dialog p {
+  margin: 0;
+}
+
+.file-action-dialog h2 {
+  color: #242629;
+  font-size: 16px;
+  font-weight: 650;
+  letter-spacing: 0;
+  line-height: 1.25;
+}
+
+.file-action-dialog p {
+  color: #525862;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.file-action-dialog strong {
+  color: #242629;
+  font-weight: 650;
+}
+
+.file-action-input {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0 10px;
+  border: 1px solid #c8ccd2;
+  border-radius: 6px;
+  outline: none;
+  color: #242629;
+  font: inherit;
+  font-size: 13px;
+  letter-spacing: 0;
+}
+
+.file-action-input:focus {
+  border-color: #3e6ae1;
+  box-shadow: 0 0 0 3px rgb(62 106 225 / 14%);
+}
+
+.file-action-error {
+  color: #a13f3f;
+}
+
+.file-action-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.file-action-buttons button {
+  min-width: 76px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid #d7d9de;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #242629;
+  font-size: 13px;
+  letter-spacing: 0;
+}
+
+.file-action-buttons button:hover,
+.file-action-buttons button:focus-visible {
+  outline: none;
+  background: #f1f3f5;
+}
+
+.file-action-buttons button.primary {
+  border-color: #3e6ae1;
+  background: #3e6ae1;
+  color: #ffffff;
+}
+
+.file-action-buttons button.primary:hover,
+.file-action-buttons button.primary:focus-visible {
+  background: #3459c5;
+}
+
+.file-action-buttons button.danger {
+  border-color: #c45f5f;
+  background: #b74c4c;
+  color: #ffffff;
+}
+
+.file-action-buttons button.danger:hover,
+.file-action-buttons button.danger:focus-visible {
+  background: #a13f3f;
+}
+
+.file-action-buttons button:disabled {
+  border-color: #d7d9de;
+  background: #eef0f3;
+  color: #8b8f94;
+  cursor: default;
+}
+
 .file-tree-message,
 .file-tree-root-message {
   margin: 0;

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -205,7 +205,7 @@ function App() {
             }}
             role="dialog"
           >
-            <h2>Rename</h2>
+            <h2>重命名</h2>
             <input
               autoFocus
               className="file-action-input"
@@ -221,10 +221,10 @@ function App() {
                 }}
                 type="button"
               >
-                Cancel
+                取消
               </button>
               <button className="primary" disabled={!renameValue.trim()} type="submit">
-                Rename
+                重命名
               </button>
             </div>
           </form>
@@ -233,9 +233,9 @@ function App() {
       {deleteTarget ? (
         <div className="file-action-backdrop" role="presentation">
           <div aria-label="Delete item" className="file-action-dialog" role="dialog">
-            <h2>Delete</h2>
+            <h2>删除</h2>
             <p>
-              Delete {deleteTarget.is_dir ? 'folder' : 'file'} <strong>{deleteTarget.name}</strong>?
+              删除{deleteTarget.is_dir ? '文件夹' : '文件'} <strong>{deleteTarget.name}</strong>?
             </p>
             {fileActionError ? <p className="file-action-error">{fileActionError}</p> : null}
             <div className="file-action-buttons">
@@ -246,10 +246,10 @@ function App() {
                 }}
                 type="button"
               >
-                Cancel
+                取消
               </button>
               <button className="danger" onClick={() => void deleteNode()} type="button">
-                Delete
+                删除
               </button>
             </div>
           </div>

--- a/ui/App.tsx
+++ b/ui/App.tsx
@@ -1,12 +1,13 @@
 import {openPath} from '@tauri-apps/plugin-opener';
 import {listen} from '@tauri-apps/api/event';
-import {useEffect} from 'react';
+import {useEffect, useState} from 'react';
 import {MainArea} from './components/main-area/MainArea';
 import {Sidebar} from './components/sidebar/Sidebar';
 import {ToolPanel} from './components/tools/ToolPanel';
 import {WindowControls} from './components/window-controls/WindowControls';
 import {useAppLayout} from './hooks/useAppLayout';
 import {useFileExplorer} from './hooks/useFileExplorer';
+import type {TreeNode} from './hooks/useFileExplorer';
 import {useMainAreaTabs} from './hooks/useMainAreaTabs';
 import {getAbsoluteFilePath, getFileOpenMode} from './lib/fileHandlers';
 import './App.css';
@@ -22,6 +23,10 @@ function App() {
   const fileExplorer = useFileExplorer();
   const mainAreaTabs = useMainAreaTabs();
   const isWindows = isWindowsPlatform();
+  const [deleteTarget, setDeleteTarget] = useState<TreeNode>();
+  const [fileActionError, setFileActionError] = useState<string>();
+  const [renameTarget, setRenameTarget] = useState<TreeNode>();
+  const [renameValue, setRenameValue] = useState('');
 
   function closeActiveTab() {
     if (mainAreaTabs.activeTab) {
@@ -83,6 +88,53 @@ function App() {
     mainAreaTabs.openFile(node);
   }
 
+  function requestRename(node: TreeNode) {
+    setFileActionError(undefined);
+    setRenameTarget(node);
+    setRenameValue(node.name);
+  }
+
+  async function renameNode() {
+    if (!renameTarget) {
+      return;
+    }
+
+    const newName = renameValue.trim();
+    if (!newName || newName === renameTarget.name) {
+      return;
+    }
+
+    try {
+      const newPath = await fileExplorer.renameNode(renameTarget, newName);
+      mainAreaTabs.renamePath(renameTarget.path, newPath, newName);
+      setRenameTarget(undefined);
+      setRenameValue('');
+      setFileActionError(undefined);
+    } catch (error) {
+      setFileActionError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
+  function requestDelete(node: TreeNode) {
+    setFileActionError(undefined);
+    setDeleteTarget(node);
+  }
+
+  async function deleteNode() {
+    if (!deleteTarget) {
+      return;
+    }
+
+    try {
+      await fileExplorer.deleteNode(deleteTarget);
+      mainAreaTabs.closePath(deleteTarget.path);
+      setDeleteTarget(undefined);
+      setFileActionError(undefined);
+    } catch (error) {
+      setFileActionError(error instanceof Error ? error.message : String(error));
+    }
+  }
+
   return (
     <main
       className={`app-layout${isWindows ? ' is-windows' : ''}${appLayout.isResizingPanel ? ' resizing-panel' : ''}`}
@@ -118,6 +170,8 @@ function App() {
           directoryStates={fileExplorer.directoryStates}
           isLoadingRoot={fileExplorer.isLoadingRoot}
           nodes={fileExplorer.nodes}
+          onDelete={requestDelete}
+          onRename={requestRename}
           onResizeKeyDown={(event) => appLayout.resizePanelWithKeyboard('left', event)}
           onResizePointerDown={(event) => appLayout.startPanelResize('left', event)}
           onSelect={selectNode}
@@ -140,6 +194,67 @@ function App() {
           panelWidth={appLayout.rightPanelWidth}
         />
       )}
+      {renameTarget ? (
+        <div className="file-action-backdrop" role="presentation">
+          <form
+            aria-label="Rename item"
+            className="file-action-dialog"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void renameNode();
+            }}
+            role="dialog"
+          >
+            <h2>Rename</h2>
+            <input
+              autoFocus
+              className="file-action-input"
+              onChange={(event) => setRenameValue(event.target.value)}
+              value={renameValue}
+            />
+            {fileActionError ? <p className="file-action-error">{fileActionError}</p> : null}
+            <div className="file-action-buttons">
+              <button
+                onClick={() => {
+                  setRenameTarget(undefined);
+                  setFileActionError(undefined);
+                }}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button className="primary" disabled={!renameValue.trim()} type="submit">
+                Rename
+              </button>
+            </div>
+          </form>
+        </div>
+      ) : null}
+      {deleteTarget ? (
+        <div className="file-action-backdrop" role="presentation">
+          <div aria-label="Delete item" className="file-action-dialog" role="dialog">
+            <h2>Delete</h2>
+            <p>
+              Delete {deleteTarget.is_dir ? 'folder' : 'file'} <strong>{deleteTarget.name}</strong>?
+            </p>
+            {fileActionError ? <p className="file-action-error">{fileActionError}</p> : null}
+            <div className="file-action-buttons">
+              <button
+                onClick={() => {
+                  setDeleteTarget(undefined);
+                  setFileActionError(undefined);
+                }}
+                type="button"
+              >
+                Cancel
+              </button>
+              <button className="danger" onClick={() => void deleteNode()} type="button">
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/ui/components/sidebar/Sidebar.tsx
+++ b/ui/components/sidebar/Sidebar.tsx
@@ -9,6 +9,10 @@ type FileTreeContextMenu = {
   y: number;
 };
 
+const contextMenuHeight = 76;
+const contextMenuWidth = 168;
+const contextMenuViewportMargin = 8;
+
 function getFileNameParts(node: TreeNode) {
   if (node.is_dir) {
     return {extension: '', name: node.name};
@@ -194,7 +198,17 @@ export function Sidebar({
   function showContextMenu(event: MouseEvent, node: TreeNode) {
     event.preventDefault();
     event.stopPropagation();
-    setContextMenu({node, x: event.clientX, y: event.clientY});
+    setContextMenu({
+      node,
+      x: Math.max(
+        contextMenuViewportMargin,
+        Math.min(event.clientX, window.innerWidth - contextMenuWidth - contextMenuViewportMargin)
+      ),
+      y: Math.max(
+        contextMenuViewportMargin,
+        Math.min(event.clientY, window.innerHeight - contextMenuHeight - contextMenuViewportMargin)
+      ),
+    });
   }
 
   return (
@@ -229,10 +243,9 @@ export function Sidebar({
             role="menuitem"
             type="button"
           >
-            Rename
+            重命名
           </button>
           <button
-            className="danger"
             onClick={() => {
               onDelete(contextMenu.node);
               setContextMenu(undefined);
@@ -240,7 +253,7 @@ export function Sidebar({
             role="menuitem"
             type="button"
           >
-            Delete
+            删除
           </button>
         </div>
       ) : null}

--- a/ui/components/sidebar/Sidebar.tsx
+++ b/ui/components/sidebar/Sidebar.tsx
@@ -1,6 +1,13 @@
-import type {CSSProperties, KeyboardEvent, PointerEvent} from 'react';
+import {useEffect, useState} from 'react';
+import type {CSSProperties, KeyboardEvent, MouseEvent, PointerEvent} from 'react';
 import {getDirectoryStateFromRecord} from '../../hooks/useFileExplorer';
 import type {DirectoryState, TreeNode} from '../../hooks/useFileExplorer';
+
+type FileTreeContextMenu = {
+  node: TreeNode;
+  x: number;
+  y: number;
+};
 
 function getFileNameParts(node: TreeNode) {
   if (node.is_dir) {
@@ -26,6 +33,7 @@ function FileTreeRow({
   directoryStates,
   isSelected,
   onSelect,
+  onShowContextMenu,
   selectedPath,
 }: {
   depth: number;
@@ -34,6 +42,7 @@ function FileTreeRow({
   directoryStates: Record<string, DirectoryState>;
   isSelected: boolean;
   onSelect: (node: TreeNode) => void;
+  onShowContextMenu: (event: MouseEvent, node: TreeNode) => void;
   selectedPath?: string;
 }) {
   const isOpen = node.is_dir && directoryState.expanded;
@@ -47,6 +56,7 @@ function FileTreeRow({
         onClick={() => {
           onSelect(node);
         }}
+        onContextMenu={(event) => onShowContextMenu(event, node)}
         style={{'--tree-depth': depth} as CSSProperties}
         title={node.name}
         type="button"
@@ -82,6 +92,7 @@ function FileTreeRow({
           directoryStates={directoryStates}
           nodes={node.children}
           onSelect={onSelect}
+          onShowContextMenu={onShowContextMenu}
           selectedPath={selectedPath}
         />
       ) : null}
@@ -94,12 +105,14 @@ function FileTreeList({
   directoryStates,
   nodes,
   onSelect,
+  onShowContextMenu,
   selectedPath,
 }: {
   depth: number;
   directoryStates?: Record<string, DirectoryState>;
   nodes: TreeNode[];
   onSelect: (node: TreeNode) => void;
+  onShowContextMenu: (event: MouseEvent, node: TreeNode) => void;
   selectedPath?: string;
 }) {
   const states = directoryStates ?? {};
@@ -115,6 +128,7 @@ function FileTreeList({
           key={node.path}
           node={node}
           onSelect={onSelect}
+          onShowContextMenu={onShowContextMenu}
           selectedPath={selectedPath}
         />
       ))}
@@ -126,6 +140,8 @@ export function Sidebar({
   directoryStates,
   isLoadingRoot,
   nodes,
+  onDelete,
+  onRename,
   onResizeKeyDown,
   onResizePointerDown,
   onSelect,
@@ -136,6 +152,8 @@ export function Sidebar({
   directoryStates: Record<string, DirectoryState>;
   isLoadingRoot: boolean;
   nodes: TreeNode[];
+  onDelete: (node: TreeNode) => void;
+  onRename: (node: TreeNode) => void;
   onResizeKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
   onResizePointerDown: (event: PointerEvent<HTMLElement>) => void;
   onSelect: (node: TreeNode) => void;
@@ -143,6 +161,42 @@ export function Sidebar({
   rootError?: string;
   selectedPath?: string;
 }) {
+  const [contextMenu, setContextMenu] = useState<FileTreeContextMenu>();
+
+  useEffect(() => {
+    if (!contextMenu) {
+      return;
+    }
+
+    function closeContextMenu() {
+      setContextMenu(undefined);
+    }
+
+    function closeContextMenuOnEscape(event: globalThis.KeyboardEvent) {
+      if (event.key === 'Escape') {
+        closeContextMenu();
+      }
+    }
+
+    window.addEventListener('click', closeContextMenu);
+    window.addEventListener('keydown', closeContextMenuOnEscape);
+    window.addEventListener('resize', closeContextMenu);
+    window.addEventListener('scroll', closeContextMenu, true);
+
+    return () => {
+      window.removeEventListener('click', closeContextMenu);
+      window.removeEventListener('keydown', closeContextMenuOnEscape);
+      window.removeEventListener('resize', closeContextMenu);
+      window.removeEventListener('scroll', closeContextMenu, true);
+    };
+  }, [contextMenu]);
+
+  function showContextMenu(event: MouseEvent, node: TreeNode) {
+    event.preventDefault();
+    event.stopPropagation();
+    setContextMenu({node, x: event.clientX, y: event.clientY});
+  }
+
   return (
     <aside className="sidebar" aria-label="Left sidebar">
       <nav className="file-tree" aria-label="Files">
@@ -154,10 +208,42 @@ export function Sidebar({
             directoryStates={directoryStates}
             nodes={nodes}
             onSelect={onSelect}
+            onShowContextMenu={showContextMenu}
             selectedPath={selectedPath}
           />
         ) : null}
       </nav>
+      {contextMenu ? (
+        <div
+          className="file-tree-context-menu"
+          onClick={(event) => event.stopPropagation()}
+          onPointerDown={(event) => event.stopPropagation()}
+          role="menu"
+          style={{left: contextMenu.x, top: contextMenu.y}}
+        >
+          <button
+            onClick={() => {
+              onRename(contextMenu.node);
+              setContextMenu(undefined);
+            }}
+            role="menuitem"
+            type="button"
+          >
+            Rename
+          </button>
+          <button
+            className="danger"
+            onClick={() => {
+              onDelete(contextMenu.node);
+              setContextMenu(undefined);
+            }}
+            role="menuitem"
+            type="button"
+          >
+            Delete
+          </button>
+        </div>
+      ) : null}
       <div
         aria-label="Resize file explorer"
         aria-orientation="vertical"

--- a/ui/hooks/useFileExplorer.ts
+++ b/ui/hooks/useFileExplorer.ts
@@ -1,5 +1,5 @@
 import {invoke} from '@tauri-apps/api/core';
-import {useCallback, useEffect, useState} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import type {FileNode} from '../types';
 
 export type TreeNode = FileNode & {
@@ -17,10 +17,12 @@ export type FileExplorerState = {
   nodes: TreeNode[];
   directoryStates: Record<string, DirectoryState>;
   selectedPath?: string;
+  deleteNode: (node: TreeNode) => Promise<void>;
   isLoadingRoot: boolean;
   rootError?: string;
   getDirectoryState: (path: string) => DirectoryState;
   refreshRoot: () => Promise<void>;
+  renameNode: (node: TreeNode, newName: string) => Promise<string>;
   selectNode: (node: TreeNode) => void;
   toggleDirectory: (node: TreeNode) => Promise<void>;
 };
@@ -48,6 +50,42 @@ function insertChildren(nodes: TreeNode[], path: string, children: TreeNode[]): 
   });
 }
 
+function getParentPath(path: string) {
+  const separatorIndex = path.lastIndexOf('/');
+  return separatorIndex === -1 ? undefined : path.slice(0, separatorIndex);
+}
+
+function getRenamedPath(path: string, newName: string) {
+  const parentPath = getParentPath(path);
+  return parentPath ? `${parentPath}/${newName}` : newName;
+}
+
+function isWithinPath(path: string, parentPath: string) {
+  return path === parentPath || path.startsWith(`${parentPath}/`);
+}
+
+function replacePathPrefix(path: string, oldPath: string, newPath: string) {
+  if (path === oldPath) {
+    return newPath;
+  }
+
+  if (path.startsWith(`${oldPath}/`)) {
+    return `${newPath}${path.slice(oldPath.length)}`;
+  }
+
+  return path;
+}
+
+function renameDirectoryStates(
+  states: Record<string, DirectoryState>,
+  oldPath: string,
+  newPath: string
+): Record<string, DirectoryState> {
+  return Object.fromEntries(
+    Object.entries(states).map(([path, state]) => [replacePathPrefix(path, oldPath, newPath), state])
+  );
+}
+
 export function useFileExplorer(): FileExplorerState {
   const [nodes, setNodes] = useState<TreeNode[]>([]);
   const [directoryStates, setDirectoryStates] = useState<Record<string, DirectoryState>>({});
@@ -55,26 +93,58 @@ export function useFileExplorer(): FileExplorerState {
   const [isLoadingRoot, setIsLoadingRoot] = useState(true);
   const [rootError, setRootError] = useState<string>();
   const [chuqinRootPath, setChuqinRootPath] = useState('');
+  const directoryStatesRef = useRef(directoryStates);
+
+  useEffect(() => {
+    directoryStatesRef.current = directoryStates;
+  }, [directoryStates]);
 
   const loadDirectory = useCallback(async (path?: string) => {
     const entries = await invoke<TreeNode[]>('files_list', {path});
     return entries;
   }, []);
 
+  const loadExpandedTree = useCallback(
+    async (entries: TreeNode[], states: Record<string, DirectoryState>): Promise<TreeNode[]> => {
+      return Promise.all(
+        entries.map(async (node) => {
+          if (!node.is_dir || !getDirectoryStateFromRecord(states, node.path).expanded) {
+            return node;
+          }
+
+          try {
+            const children = await loadDirectory(node.path);
+            return {...node, children: await loadExpandedTree(children, states)};
+          } catch {
+            return node;
+          }
+        })
+      );
+    },
+    [loadDirectory]
+  );
+
+  const refreshTree = useCallback(
+    async (states: Record<string, DirectoryState>) => {
+      const [rootPath, entries] = await Promise.all([invoke<string>('files_root'), loadDirectory()]);
+      setChuqinRootPath(rootPath);
+      setNodes(await loadExpandedTree(entries, states));
+    },
+    [loadDirectory, loadExpandedTree]
+  );
+
   const refreshRoot = useCallback(async () => {
     setIsLoadingRoot(true);
     setRootError(undefined);
 
     try {
-      const [rootPath, entries] = await Promise.all([invoke<string>('files_root'), loadDirectory()]);
-      setChuqinRootPath(rootPath);
-      setNodes(entries);
+      await refreshTree(directoryStatesRef.current);
     } catch (error) {
       setRootError(error instanceof Error ? error.message : String(error));
     } finally {
       setIsLoadingRoot(false);
     }
-  }, [loadDirectory]);
+  }, [refreshTree]);
 
   useEffect(() => {
     let isActive = true;
@@ -98,6 +168,47 @@ export function useFileExplorer(): FileExplorerState {
   const selectNode = useCallback((node: TreeNode) => {
     setSelectedPath(node.path);
   }, []);
+
+  const renameNode = useCallback(
+    async (node: TreeNode, newName: string) => {
+      const trimmedName = newName.trim();
+
+      if (!trimmedName || trimmedName === node.name) {
+        return node.path;
+      }
+
+      await invoke<void>('files_rename', {oldPath: node.path, newName: trimmedName});
+
+      const newPath = getRenamedPath(node.path, trimmedName);
+      const nextDirectoryStates = node.is_dir
+        ? renameDirectoryStates(directoryStates, node.path, newPath)
+        : directoryStates;
+
+      setDirectoryStates(nextDirectoryStates);
+      setSelectedPath((currentPath) =>
+        currentPath ? replacePathPrefix(currentPath, node.path, newPath) : currentPath
+      );
+      await refreshTree(nextDirectoryStates);
+
+      return newPath;
+    },
+    [directoryStates, refreshTree]
+  );
+
+  const deleteNode = useCallback(
+    async (node: TreeNode) => {
+      await invoke<void>('files_delete', {path: node.path});
+
+      const nextDirectoryStates = Object.fromEntries(
+        Object.entries(directoryStates).filter(([path]) => !isWithinPath(path, node.path))
+      );
+
+      setDirectoryStates(nextDirectoryStates);
+      setSelectedPath((currentPath) => (currentPath && isWithinPath(currentPath, node.path) ? undefined : currentPath));
+      await refreshTree(nextDirectoryStates);
+    },
+    [directoryStates, refreshTree]
+  );
 
   const toggleDirectory = useCallback(
     async (node: TreeNode) => {
@@ -152,10 +263,12 @@ export function useFileExplorer(): FileExplorerState {
     nodes,
     directoryStates,
     selectedPath,
+    deleteNode,
     isLoadingRoot,
     rootError,
     getDirectoryState,
     refreshRoot,
+    renameNode,
     selectNode,
     toggleDirectory,
   };

--- a/ui/hooks/useMainAreaTabs.ts
+++ b/ui/hooks/useMainAreaTabs.ts
@@ -9,7 +9,9 @@ export type MainAreaTabsState = {
   activeTab: MainAreaTab | undefined;
   activeTabId: string;
   closeTab: (tabId: string) => void;
+  closePath: (path: string) => void;
   openFile: (node: FileNode) => MainAreaTab | null;
+  renamePath: (oldPath: string, newPath: string, newName: string) => void;
   selectTab: (tabId: string) => void;
   tabs: MainAreaTab[];
 };
@@ -28,6 +30,26 @@ function fileNodeToTab(node: FileNode): MainAreaTab | null {
     title: node.name,
     type: 'file',
   };
+}
+
+function basename(path: string) {
+  return path.split('/').pop() ?? path;
+}
+
+function isWithinPath(path: string, parentPath: string) {
+  return path === parentPath || path.startsWith(`${parentPath}/`);
+}
+
+function replacePathPrefix(path: string, oldPath: string, newPath: string) {
+  if (path === oldPath) {
+    return newPath;
+  }
+
+  if (path.startsWith(`${oldPath}/`)) {
+    return `${newPath}${path.slice(oldPath.length)}`;
+  }
+
+  return path;
 }
 
 export function useMainAreaTabs(): MainAreaTabsState {
@@ -75,11 +97,58 @@ export function useMainAreaTabs(): MainAreaTabsState {
     });
   }
 
+  function closePath(path: string) {
+    setTabs((currentTabs) => {
+      const nextTabs = currentTabs.filter((tab) => tab.type !== 'file' || !isWithinPath(tab.path, path));
+
+      if (nextTabs.some((tab) => tab.id === activeTabId)) {
+        return nextTabs;
+      }
+
+      setActiveTabId(nextTabs[0]?.id ?? '');
+      return nextTabs;
+    });
+  }
+
+  function renamePath(oldPath: string, newPath: string, newName: string) {
+    setTabs((currentTabs) => {
+      let nextActiveTabId = activeTabId;
+      const nextTabs = currentTabs.map((tab) => {
+        if (tab.type !== 'file') {
+          return tab;
+        }
+
+        if (!isWithinPath(tab.path, oldPath)) {
+          return tab;
+        }
+
+        const nextPath = replacePathPrefix(tab.path, oldPath, newPath);
+        const nextId = `file:${nextPath}`;
+
+        if (tab.id === activeTabId) {
+          nextActiveTabId = nextId;
+        }
+
+        return {
+          ...tab,
+          id: nextId,
+          path: nextPath,
+          title: tab.path === oldPath ? newName : basename(nextPath),
+        };
+      });
+
+      setActiveTabId(nextActiveTabId);
+      return nextTabs;
+    });
+  }
+
   return {
     activeTab,
     activeTabId,
     closeTab,
+    closePath,
     openFile,
+    renamePath,
     selectTab,
     tabs,
   };


### PR DESCRIPTION
## Summary
- add sidebar file/folder context menu actions for rename and delete
- keep affected file tabs in sync after rename/delete
- polish the menu with an Obsidian-style translucent macOS/Windows look

## Verification
- pnpm build
- pnpm format:check
- cargo check